### PR TITLE
Run e2e tests on Travis instead of Browserstack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
+dist: trusty
+sudo: required
 language: node_js
 node_js:
 - '8'
+addons:
+  chrome: stable
 before_install:
+- wget "http://chromedriver.storage.googleapis.com/2.35/chromedriver_linux64.zip"
+- unzip chromedriver_linux64.zip -d $HOME/bin
+- export PATH=$PATH:$HOME/bin
 - npm i -g yarn
 install:
 - npm i -g codecov
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3
 script:
 - yarn && yarn test:cov && yarn start-and-e2e
-addons:
-  browserstack:
-    username: mohammad222
-    access_key:
-      secure: Fg0Ravo7z290/clYXsrTmUawsq9oHO4iihWhvq6UhLL50P9KUnrcN46dsOk2turSk4rhzCs1OJpqIDmD1iDeVtUPnazopffiCe2I51wvhStiWF0JJwSSJJyG8Oh7HMa2mVXVnTMsGnjoUaqG09uKEAMG7+Ra7zkB9JvcocCN30LAQK1Zj+iT0Sr8MiTkMz72PT6i9TU7j5Le+k4zQvdPPWlRh6poO/n0+QivB6VkeBLTdY/xictqzwVP+/WKhvp7wSnhOsX/M/udZWVx6C5Ag/zAs8AYNlLQ2IeAY84eiH9rfokZ97YZxslzrnu37cJw37ICPqZV4Trw5bOk5I491b2GrLblA4o3OxDQmT85tdHyxomO2s5FTVPS2AwQ+aQ4GW8/tEX+MkYgkdOvUqzOF9wVvjpv2RNb//EMCa4IF5DOsLcGIfqkJ0zZXHca9fxY835TTZwPprCXct94M/JvUkyx+mFDUGjQFcLJIdqPI34+tbgmita9Pk3inLAmwHeuBm4JI1L7FbEowtRoHuCgWIPbyD73SKZ8lua/N/mVBbJAy9nQafC+YuQ/YM3RtTI6Gnovy1b/TTqlT5D5qLtFMT/Z5lCPArvf9xsvAlCvEI3uIbSPJEJ9eWNWBoXJR/sU2GP6+HhSe/m+cNk8Zg3/CsgvmxFKy+vMpkqVVTgFlXo=
-env:
-  global:
-  - BROWSERSTACK_USER: mohammad222
-  - secure: I3oK8V9capDN8PxCBQrdHHNVtrad1ucd5wnDOK0kOIHUOEnX0lXCCGLwBXJnsubWUWYi0JbIpVAUqX/H9jUrTtcOdj1eVTFjhoz/Xfs4DRVFMFAu3lm8FoTV6CSVK57kNGasXrm6gQBDMA/8dnajCQNM326JEOPVgBsHSTTFo4eOgdldFseRDX8u85VX7bQPz0RdBVprBGD5AYffs15e/SZsvvucPYDULZaofpch85K5vEWBLeJIbJangPwgAQyDnN1BMkXMyoQp1mrMVCBT3LJJv/Bu3gM4E6efR34av9ZI3D3LU8YBvT+fv6yw2pPw/1wujcCHmWYRCxkDheCLrOIT78L7EpmagIoGr9u3gji5g2JcvNdOvfTM+lixuSd5q1AAIsxlzqyTAQvAUaI4KqggvqReNVuwlE9HH4cNhrapO1ehVcfz6RpwAxsChQGbZsQlCKELsaundz0jDegwFwqMw83lGhzG5i22bitwgjNB6zUezAWmwzFku0gUxo1Z5k7EHrRO0Z91Y7fAB/OLc55i17AE8N061Npu71kCDng+Kgw0Db1jCLSMhuOOUVN+MOYiqqvb1/Se8kKzw8VwLUyihFa2E5NKwASA6fUEH96JOXqE4rsquPnj6BDyRyGFTsDZXDkWRVFyowHN6Oa9lzFaEM9LROKC50Im0KQZj90=

--- a/src/__tests__/e2e/ideas.e2e.js
+++ b/src/__tests__/e2e/ideas.e2e.js
@@ -33,13 +33,14 @@ it('should test ideas functionality', async (done) => {
   await click('#add-and-continue');
   await type('.NewIdeaDialog input', 'even another cool idea');
   await click('#add-and-finish');
+  await wait(500);
   let numberOfIdeas = await count('.Idea');
   expect(numberOfIdeas).toBe(3);
   await wait(500);
 
   // Delete idea
   await click('.Idea:first-of-type .delete');
-  await wait(1100);
+  await wait(500);
   numberOfIdeas = await count('.Idea');
   expect(numberOfIdeas).toBe(2);
   await wait(500);
@@ -73,6 +74,7 @@ it('should test ideas functionality', async (done) => {
   await type('#estimated-time', 20);
   await wait(500);
   await click('#add-and-finish');
+  await wait(500);
   numberOfIdeas = await count('.Idea');
   expect(numberOfIdeas).toBe(1);
   await wait(500);

--- a/src/__tests__/e2e/tasks.e2e.js
+++ b/src/__tests__/e2e/tasks.e2e.js
@@ -44,13 +44,14 @@ it('should test tasks functionality', async (done) => {
   await type('#estimated-time', 20);
   await wait(500);
   await click('#add-and-finish');
+  await wait(500);
   let numberOfTasks = await count('.Task');
   expect(numberOfTasks).toBe(2);
   await wait(500);
 
   // Delete task
   await click('.Task .delete');
-  await wait(1100);
+  await wait(500);
   numberOfTasks = await count('.Task');
   expect(numberOfTasks).toBe(1);
   await wait(500);
@@ -66,7 +67,7 @@ it('should test tasks functionality', async (done) => {
 
   // Mark task as done
   await click('.Task .mark-as-done');
-  await wait(1100);
+  await wait(500);
   numberOfTasks = await count('.Task');
   expect(numberOfTasks).toBe(1);
   await wait(500);

--- a/src/lib/e2eUtils.js
+++ b/src/lib/e2eUtils.js
@@ -3,17 +3,8 @@ import webdriver from 'selenium-webdriver';
 
 const { By, Key } = webdriver;
 
-const capabilities = {
-  browserName: 'chrome',
-  'browserstack.local': 'true',
-  'browserstack.localIdentifier': process.env.BROWSERSTACK_LOCAL_IDENTIFIER,
-  'browserstack.user': process.env.BROWSERSTACK_USER,
-  'browserstack.key': process.env.BROWSERSTACK_KEY,
-};
-
 const createDriver = () => new webdriver.Builder()
-  .usingServer('http://hub-cloud.browserstack.com/wd/hub')
-  .forBrowser('chrome').withCapabilities(capabilities)
+  .forBrowser('chrome')
   .build();
 const utilsFactory = driver => ({
   init() {


### PR DESCRIPTION
Browserstack doesn't let the project forks to run e2e tests on their servers and raise an error. An example of a user with such a problem can be found [here](https://github.com/mkermani144/wanna/pull/252#issuecomment-348962313).  
Using Travis itself to run e2e tests seem to fix the problem.